### PR TITLE
add manifest files that will sync with project

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@
 4. Enter your appId, should be found in your capacitor.config.json file.
 5. Click Save and Continue, then click "authorize your app now" button.
 6. Enter your sha-1 and confirm
-7. [Add manifest configuration](https://developers.google.com/games/services/android/quickstart#step_3_modify_your_code)
+7. In your native android project, add your app id string to your strings xml file.
+    - your strings xml file can be found in android/app/src/main/res/values/strings.xml
 8. Go to testing tab and add test account.
 9. Add the plugin to main activity after running npx cap sync
 

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,5 +1,14 @@
 
   <manifest xmlns:android="http://schemas.android.com/apk/res/android"
       package="io.openforge.gameservices.capacitorgameservices">
+
+      <application>
+        <meta-data android:name="com.google.android.gms.games.APP_ID"
+              android:value="@string/app_id" />
+        <meta-data android:name="com.google.android.gms.version"
+            android:value="@integer/google_play_services_version"/>
+      </application>
+      
+
   </manifest>
   

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openforge/capacitor-game-services",
-  "version": "1.0.2",
+  "version": "1.0.3-beta.1",
   "description": "A native only plugin for googles play services library and apples game center library",
   "main": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",


### PR DESCRIPTION
Capacitor will sync the manifest of the plugin when wrapped in an application tag.
Moving part of the configuration to this plugin.
Apps that declared these meta tags will not fail when syncing with a plugin that does as well.